### PR TITLE
fix(ossec): fix bug with rocky9 due to var not being defined

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -226,6 +226,8 @@ class wazuh::params_agent {
   # active-response
   $active_response_linux_ca_store = '/var/ossec/etc/wpk_root.pem'
 
+  ## Ensure variable exists
+  $ossec_service_provider = undef
 
   # OS specific configurations
   case $::kernel {


### PR DESCRIPTION
Error on rocky 9 systems:

```
Notice: Catalog compiled by compiler.v8.provisioner.dropfort.com
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Unknown variable: 'wazuh::params_agent::ossec_service_provider'. (file: /etc/puppetlabs/code/environments/8_10_x/modules/wazuh/manifests/agent.pp, line: 577, column: 24) on node ...
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```